### PR TITLE
Clear pip cache after we are done installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ rm get-pip.py
 RUN pip3 install numpy biopython matplotlib multiprocess pymysql python-igraph pickle5>=0.0.10 psutil
 RUN pip3 install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
 
-# Clear pip cache, we don't need it anymore
+# Clear pip cache
 RUN rm -rf /root/.cache/pip
 
 # Install and setup MMseqs2

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ rm get-pip.py
 RUN pip3 install numpy biopython matplotlib multiprocess pymysql python-igraph pickle5>=0.0.10 psutil
 RUN pip3 install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
 
+# Clear pip cache, we don't need it anymore
+RUN rm -rf /root/.cache/pip
+
 # Install and setup MMseqs2
 RUN wget -O /opt/mmseqs-linux-sse41.tar.gz https://mmseqs.com/latest/mmseqs-linux-sse41.tar.gz && tar xvfz /opt/mmseqs-linux-sse41.tar.gz -C /opt/ && ln -s /opt/mmseqs/bin/mmseqs /usr/local/bin/
 


### PR DESCRIPTION
We don't need it anymore and it takes up ~77MB:

$ du -hs /root/.cache/pip/
77M	/root/.cache/pip/