### PR TITLE
Remove MMseqs2 archive after extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN pip3 install numpy biopython matplotlib multiprocess pymysql python-igraph p
 RUN pip3 install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-1.1.0.dev0-cp37-cp37m-manylinux1_x86_64.whl
 
 # Install and setup MMseqs2
-RUN wget -O /opt/mmseqs-linux-sse41.tar.gz https://mmseqs.com/latest/mmseqs-linux-sse41.tar.gz && tar xvfz /opt/mmseqs-linux-sse41.tar.gz -C /opt/ && ln -s /opt/mmseqs/bin/mmseqs /usr/local/bin/
+RUN wget -O /opt/mmseqs-linux-sse41.tar.gz https://mmseqs.com/latest/mmseqs-linux-sse41.tar.gz && tar xvfz /opt/mmseqs-linux-sse41.tar.gz -C /opt/ && ln -s /opt/mmseqs/bin/mmseqs /usr/local/bin/ && rm /opt/mmseqs-linux-sse41.tar.gz
 
 # Install xssp-3.0.7-mkdssp
 RUN wget -O /opt/xssp-3.0.7.tar.gz https://github.com/cmbi/hssp/releases/download/3.0.7/xssp-3.0.7.tar.gz && tar xvzf /opt/xssp-3.0.7.tar.gz -C /opt/ && rm /opt/xssp-3.0.7.tar.gz


### PR DESCRIPTION
This also takes up ~30MB unnecessarily:

$ du -hs /opt/mmseqs-linux-sse41.tar.gz 
30M	/opt/mmseqs-linux-sse41.tar.gz